### PR TITLE
The code was initialising the same variable twice. This commit remove…

### DIFF
--- a/textract-pipeline/lambda/jobresultprocessor/lambda_function.py
+++ b/textract-pipeline/lambda/jobresultprocessor/lambda_function.py
@@ -69,9 +69,6 @@ def processRequest(request):
         detectForms = True
         detectTables = True
 
-    dynamodb = AwsHelper().getResource('dynamodb')
-    ddb = dynamodb.Table(outputTable)
-
     opg = OutputGenerator(jobTag, pages, bucketName, objectName, detectForms, detectTables, ddb)
     opg.run()
 


### PR DESCRIPTION
The jobprocessor lambda function is twice declaring the same variable ddb and dynamodb in processRequest() function.
dynamodb = AwsHelper().getResource("dynamodb")
ddb = dynamodb.Table(outputTable)

 issue #11

*Description of changes:*
This commit removes one of the duplicated declarations of ddb and dynamodb variables. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
